### PR TITLE
Create branch when inside repo folder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,16 +22,16 @@ git config --global user.email "$INPUT_USER_EMAIL"
 git config --global user.name "$INPUT_USER_NAME"
 git clone --single-branch --branch $INPUT_DESTINATION_BRANCH "https://x-access-token:$API_TOKEN_GITHUB@github.com/$INPUT_DESTINATION_REPO.git" "$CLONE_DIR"
 
+echo "Copying contents to git repo"
+mkdir -p $CLONE_DIR/$INPUT_DESTINATION_FOLDER
+cp -R "$INPUT_SOURCE_FILE" "$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
+cd "$CLONE_DIR"
+
 if [ ! -z "$INPUT_DESTINATION_BRANCH_CREATE" ]
 then
   git checkout -b "$INPUT_DESTINATION_BRANCH_CREATE"
   OUTPUT_BRANCH="$INPUT_DESTINATION_BRANCH_CREATE"
 fi
-
-echo "Copying contents to git repo"
-mkdir -p $CLONE_DIR/$INPUT_DESTINATION_FOLDER
-cp -R "$INPUT_SOURCE_FILE" "$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
-cd "$CLONE_DIR"
 
 if [ -z "$INPUT_COMMIT_MESSAGE" ]
 then


### PR DESCRIPTION
One cannot create a new branch if not inside the repository folder. I.e., First
`cd "$CLONE_DIR"` and only then `git checkout -b`