### PR TITLE
Fix input_commit_message in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This GitHub Action copies a file from the current repository to a location in an
             destination_folder: 'test-dir'
             user_email: 'example@email.com'
             user_name: 'dmnemec'
-            commit_message: 'A custom message for the commit'
+            input_commit_message: 'A custom message for the commit'
 
 # Variables
 * source_file: The file or directory to be moved. Uses the same syntax as the `cp` command. Incude the path for any files not in the repositories root directory.
@@ -33,7 +33,7 @@ This GitHub Action copies a file from the current repository to a location in an
 * user_name: The GitHub username associated with the API token secret.
 * destination_branch: [optional] The branch of the source repo to update, if not master.
 * destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
-* commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
+* input_commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
 
 # Behavior Notes
 The action will create any destination paths if they don't exist. It will also overwrite existing files if they already exist in the locations being copied to. It will not delete the entire destination repository.


### PR DESCRIPTION
The Dockerfile appears to be using this variable, not `commit_message`.