### PR TITLE
Changed: How to call variables in shell script to literal. 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ git clone --single-branch --branch $INPUT_DESTINATION_BRANCH "https://x-access-t
 
 echo "Copying contents to git repo"
 mkdir -p $CLONE_DIR/$INPUT_DESTINATION_FOLDER
-cp -R "$INPUT_SOURCE_FILE" "$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
+cp -R ${INPUT_SOURCE_FILE} "$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
 cd "$CLONE_DIR"
 
 if [ ! -z "$INPUT_DESTINATION_BRANCH_CREATE" ]


### PR DESCRIPTION
# Summary
Changed how to call variables in shell script to literal . it's for cp command wildcard enable.

## Detail
In the code so far
`cp -R 'your_dir/*' target-dir`
A single quote was inserted like this, it became a string, and it wasn't working.

![image](https://user-images.githubusercontent.com/7081444/113558308-644d7700-963a-11eb-8236-25f0f6af5d60.png)


## Depending on this change.

![image](https://user-images.githubusercontent.com/7081444/113560651-4550e400-963e-11eb-85ee-2fb8486abe4f.png)




