### PR TITLE
Fix GIT_SERVER var name, no longer required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
     - ${{ inputs.destination-branch }}
     - ${{ inputs.destination-branch-create }}
     - ${{ inputs.commit-message }}
-    - ${{ inputs.github-server }}
+    - ${{ inputs.git-server }}
     - ${{ inputs.rename }}
     - ${{ inputs.use-rsync }}
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
   git_server:
     description: 'Git server host, default github.com'
-    required: true
+    required: false
     default: github.com
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ CLONE_DIR=$(mktemp -d)
 echo "Cloning destination git repository"
 git config --global user.email "$INPUT_USER_EMAIL"
 git config --global user.name "$INPUT_USER_NAME"
-git clone --single-branch --branch $INPUT_DESTINATION_BRANCH "https://x-access-token:$API_TOKEN_GITHUB@$INPUT_GITHUB_SERVER/$INPUT_DESTINATION_REPO.git" "$CLONE_DIR"
+git clone --single-branch --branch $INPUT_DESTINATION_BRANCH "https://x-access-token:$API_TOKEN_GITHUB@$INPUT_GIT_SERVER/$INPUT_DESTINATION_REPO.git" "$CLONE_DIR"
 
 if [ ! -z "$INPUT_RENAME" ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,11 @@ then
   return 1
 fi
 
+if [ -z "$INPUT_GIT_SERVER"]
+then
+  INPUT_GIT_SERVER="github.com"
+fi
+
 if [ -z "$INPUT_DESTINATION_BRANCH" ]
 then
   INPUT_DESTINATION_BRANCH=main
@@ -51,7 +56,7 @@ fi
 
 if [ -z "$INPUT_COMMIT_MESSAGE" ]
 then
-  INPUT_COMMIT_MESSAGE="Update from https://$INPUT_GITHUB_SERVER/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+  INPUT_COMMIT_MESSAGE="Update from https://$INPUT_GIT_SERVER/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
 fi
 
 echo "Adding git commit"


### PR DESCRIPTION
Should fix #44 

had the variable named INPUT_GITHUB_SERVER instead of INPUT_GIT_SERVER. Fixed that and added another check for a blank var setting it to github.com if found.