### PR TITLE
Add retry behavior when pushing failed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Git server host, default github.com'
     required: false
     default: github.com
+  retry_attempts:
+    description: 'Retry attempts if pushing commit failed'
+    required: false
+    default: "10"
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -49,6 +53,7 @@ runs:
     - ${{ inputs.git-server }}
     - ${{ inputs.rename }}
     - ${{ inputs.use-rsync }}
+    - ${{ inputs.retry_attempts }}
 branding:
   icon: 'git-commit'
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,20 @@ if git status | grep -q "Changes to be committed"
 then
   git commit --message "$INPUT_COMMIT_MESSAGE"
   echo "Pushing git commit"
-  git push -u origin HEAD:"$OUTPUT_BRANCH"
+  if git push -u origin HEAD:$OUTPUT_BRANCH; then
+    echo "Git push succeeded"
+  elif [ $((INPUT_RETRY_ATTEMPTS)) -gt 0 ]; then
+    echo "Retrying git push"
+    for (( index=0; index<$((INPUT_RETRY_ATTEMPTS)); index++ )); do
+      sleep $((1 + $RANDOM % 5))s
+      git fetch
+      git rebase
+      if git push; then
+        exit 0;
+      fi
+    done
+    echo "Can not push changes to $OUTPUT_BRANCH after retrying $INPUT_RETRY_ATTEMPTS attempts"
+  fi
 else
   echo "No changes detected"
 fi


### PR DESCRIPTION
The pushing step would fail if there are 2 or more repos do push at the same time to another repo, in that case we need to rebase the commit before pushing again.