### PR TITLE
Fix concurrent push

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ The `API_TOKEN_GITHUB` needs to be set in the `Secrets` section of your reposito
 * destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
 * commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
 * use_rsync: [optional] Uses `rsync -avh` instead of `cp -R` to perform the base operation. Currently works as an experimental feature (due to lack of testing) but can speed up updates to large collections of files with many small changes by only syncing the changes and not copying the entire contents again. Please understand your use case before using this, and provide feedback as issues if needed.
-* retry_attempts: [optional] The number of retries when pushing commit failed, defaults are 10 times.
+* retry_attempts: [optional] The number of retries when pushing commit failed.  Default: 10
 # Behavior Notes
 The action will create any destination paths if they don't exist. It will also overwrite existing files if they already exist in the locations being copied to. It will not delete the entire destination repository.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ The `API_TOKEN_GITHUB` needs to be set in the `Secrets` section of your reposito
 * destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
 * commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
 * use_rsync: [optional] Uses `rsync -avh` instead of `cp -R` to perform the base operation. Currently works as an experimental feature (due to lack of testing) but can speed up updates to large collections of files with many small changes by only syncing the changes and not copying the entire contents again. Please understand your use case before using this, and provide feedback as issues if needed.
-
+* retry_attempts: [optional] The number of retries when pushing commit failed, defaults are 10 times.
 # Behavior Notes
 The action will create any destination paths if they don't exist. It will also overwrite existing files if they already exist in the locations being copied to. It will not delete the entire destination repository.

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Git server host, default github.com'
     required: false
     default: github.com
+  retry_attempts:
+    description: 'Retry attempts if pushing commit failed'
+    required: false
+    default: "10"
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -49,6 +53,7 @@ runs:
     - ${{ inputs.git-server }}
     - ${{ inputs.rename }}
     - ${{ inputs.use-rsync }}
+    - ${{ inputs.retry_attempts }}
 branding:
   icon: 'git-commit'
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,20 @@ if git status | grep -q "Changes to be committed"
 then
   git commit --message "$INPUT_COMMIT_MESSAGE"
   echo "Pushing git commit"
-  git push -u origin HEAD:"$OUTPUT_BRANCH"
+  if git push -u origin HEAD:$OUTPUT_BRANCH; then
+    echo "Git push succeeded"
+  elif [ $((INPUT_RETRY_ATTEMPTS)) -gt 0 ]; then
+    echo "Retrying git push"
+    for (( index=0; index<$((INPUT_RETRY_ATTEMPTS)); index++ )); do
+      sleep $((1 + $RANDOM % 5))s
+      git fetch
+      git rebase
+      if git push; then
+        exit 0;
+      fi
+    done
+    echo "Can not push changes to $OUTPUT_BRANCH after retrying $INPUT_RETRY_ATTEMPTS attempts"
+  fi
 else
   echo "No changes detected"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ then
   return 1
 fi
 
-if [ -z "$INPUT_GIT_SERVER"]
+if [ -z "$INPUT_GIT_SERVER" ]
 then
   INPUT_GIT_SERVER="github.com"
 fi


### PR DESCRIPTION
The pushing step would fail if there are 2 or more repos do push at the same time to another repo, in that case we need to rebase the commit before pushing again.