### PR TITLE
Default user_email and user_name to Github Actor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,12 @@ inputs:
     required: false
   user_email:
     description: 'Email for the git commit'
-    required: true
+    default: ${{ github.actor }}@users.noreply.github.com
+    required: false
   user_name:
     description: 'GitHub username for the commit'
-    required: true
+    default: ${{ github.actor }}
+    required: false
   destination_branch:
     description: 'branch to push file to, defaults to main'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ then
   return 1
 fi
 
-if [ -z "$INPUT_GIT_SERVER"]
+if [ -z "$INPUT_GIT_SERVER" ]
 then
   INPUT_GIT_SERVER="github.com"
 fi


### PR DESCRIPTION
Uses the [GitHub Context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to default the `user_email` and `user_name` inputs