### PR TITLE
Delete the destination folder before copying files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,9 @@ else
   DEST_COPY="$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
 fi
 
+echo "Making sure the destination folder is empty."
+rm -rf "$DEST_COPY"
+
 echo "Copying contents to git repo"
 mkdir -p $CLONE_DIR/$INPUT_DESTINATION_FOLDER
 if [ -z "$INPUT_USE_RSYNC" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,8 +35,8 @@ else
   DEST_COPY="$CLONE_DIR/$INPUT_DESTINATION_FOLDER"
 fi
 
-echo "Making sure the destination folder is empty."
-rm -rf "$DEST_COPY"
+echo "Making sure the destination file does not exist or folder is empty."
+rm -rf "$DEST_COPY/$INPUT_SOURCE_FILE"
 
 echo "Copying contents to git repo"
 mkdir -p $CLONE_DIR/$INPUT_DESTINATION_FOLDER


### PR DESCRIPTION
Hi,

The issue we faced with the current script is that if the destination input branch has a folder with files and the files being copied to the destination branch don't have some of the files from that folder (which is expected - some files can be removed on purpose), then the files are not being deleted. Our proposed solution is to make sure that the destination is empty before we copy the file(s) there.