### PR TITLE
Update `actions/checkout` to @v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Mark test file
       run: |-


### PR DESCRIPTION
### Summary

This PR bumps the version of `actions/checkout` to `@v3` to prevent warnings of using an outdated Node version in `@v2`.

**Example warning**:

<img width="566" alt="warning" src="https://github.com/dmnemec/copy_file_to_another_repo_action/assets/18134219/ffb24865-a006-4cc0-93a9-b396d0193760">

**Related links**:

- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/
